### PR TITLE
Fix OpenGarage tests to use millisecond defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
 	],
 	"name": "homebridge-og",
 	"optionalDependencies": {},
-	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 1"
-	},
+        "scripts": {
+                "test": "mocha"
+        },
 	"version": "3.1.1"
 }

--- a/test/open_garage_test.js
+++ b/test/open_garage_test.js
@@ -30,8 +30,13 @@ class Characteristic {
     }
 
     triggerGetSync() {
-        var result
-        this._on['get']((err, r) => result =r )
+        let error, result
+        this._on['get']((err, r) => {
+            error = err
+            result = r
+        })
+        if (error)
+            throw error
         return result
     }
 
@@ -52,17 +57,19 @@ class Characteristic {
 }
 
 class GarageDoorOpener extends MockDevice {}
+class OccupancySensor extends MockDevice {}
 const MockHomebridge = {
     hap: {
         uuid: { generate: (input) => input },
-        Service: {GarageDoorOpener},
+        Service: {GarageDoorOpener, OccupancySensor},
         Characteristic: {
             Manufacturer: {name: "Manufacturer"},
             Model: {name: "Model"},
             SerialNumber: {name: "SerialNumber"},
             TargetDoorState: {name: "TargetDoorState", CLOSED: "T_CLOSED", OPEN: "T_OPEN"},
             CurrentDoorState: {name: "CurrentDoorState", CLOSED: "CLOSED", OPEN: "OPEN"},
-            ObstructionDetected: {name: "ObstructionDetected"}
+            ObstructionDetected: {name: "ObstructionDetected"},
+            OccupancyDetected: {name: "OccupancyDetected", OCCUPANCY_DETECTED: "DETECTED", OCCUPANCY_NOT_DETECTED: "NOT_DETECTED"}
         }
     }
 }
@@ -98,8 +105,8 @@ describe('OpenGarage', function() {
     var MockDate
     var currentDoorState
     var targetDoorState
-    let pollFrequencyMs = OpenGarageModule.defaults.pollFrequencyMs
-    var openDurationMs = OpenGarageModule.defaults.openDurationMs
+    const pollFrequencyMs = OpenGarageModule.defaults.pollFrequencySecs * 1000
+    const openDurationMs = OpenGarageModule.defaults.openCloseDurationSecs * 1000
     let Characteristic = MockHomebridge.hap.Characteristic
     let Service = MockHomebridge.hap.Service
 


### PR DESCRIPTION
## Summary
- derive the OpenGarage test timing expectations from the second-based defaults
- improve the mock HomeKit surface so error handling and occupancy checks behave like the runtime
- update the npm test script to execute the mocha suite

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d831b7d7108324aa32d6e8e52c6400