### PR TITLE
Warn when OpenGarage host is unreachable

### DIFF
--- a/lib/open_garage_api.js
+++ b/lib/open_garage_api.js
@@ -1,9 +1,11 @@
 const request = require("request-promise-native")
 
-function OpenGarageApiModule(log) {
+function OpenGarageApiModule(log, deps = {}) {
+    const requestClient = deps.request || request
     class OpenGarageApi{
         constructor({ip, key}) {
             this.key = key
+            this.ip = ip
             this.baseUrl = "http://" + ip
         }
 
@@ -16,10 +18,15 @@ function OpenGarageApiModule(log) {
 
 
         getState() {
-            return request.get({ url: this.urlFor("/jc") }).then(
+            return requestClient.get({ url: this.urlFor("/jc") }).then(
                 (body) => JSON.parse(body),
                 (err) => {
                     log("Error getting state:", err.message)
+                    let timeout = err && (err.code === "ETIMEDOUT" || (err.cause && err.cause.code === "ETIMEDOUT"))
+                    if (timeout) {
+                        const warn = typeof log.warn === "function" ? log.warn.bind(log) : log
+                        warn("Host may be down, IP:%s", this.ip)
+                    }
                     throw err
                 })
         }
@@ -46,7 +53,7 @@ function OpenGarageApiModule(log) {
                 "/cc",
                 closed ? "close=1" : "open=1")
             log(url)
-            return request.get({url}).then((body) => this._handleResponse(body))
+            return requestClient.get({url}).then((body) => this._handleResponse(body))
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
 	],
 	"name": "homebridge-og",
 	"optionalDependencies": {},
-	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 1"
-	},
+        "scripts": {
+                "test": "mocha"
+        },
 	"version": "3.1.1"
 }

--- a/test/open_garage_api_test.js
+++ b/test/open_garage_api_test.js
@@ -1,0 +1,47 @@
+const assert = require('assert')
+const util = require('util')
+const OpenGarageApiModule = require('../lib/open_garage_api.js')
+
+describe('OpenGarageApi', function() {
+    it('logs a warning when requests time out', async function() {
+        const logs = []
+        const warns = []
+        function log() {
+            logs.push(util.format.apply(util, arguments))
+        }
+        log.warn = function() {
+            warns.push(util.format.apply(util, arguments))
+        }
+
+        const request = {
+            get: () => Promise.reject(Object.assign(new Error('read ETIMEDOUT'), {code: 'ETIMEDOUT'}))
+        }
+
+        const OpenGarageApi = OpenGarageApiModule(log, {request})
+        const api = new OpenGarageApi({ip: '10.0.0.1', key: 'secret'})
+
+        await assert.rejects(() => api.getState())
+
+        assert(logs.some((message) => message.includes('Error getting state: read ETIMEDOUT')))
+        assert(warns.some((message) => message.includes('Host may be down, IP:10.0.0.1')))
+    })
+
+    it('falls back to info logging when warn is unavailable', async function() {
+        const infoLogs = []
+        function log() {
+            infoLogs.push(util.format.apply(util, arguments))
+        }
+
+        const request = {
+            get: () => Promise.reject(Object.assign(new Error('read ETIMEDOUT'), {code: 'ETIMEDOUT'}))
+        }
+
+        const OpenGarageApi = OpenGarageApiModule(log, {request})
+        const api = new OpenGarageApi({ip: '10.0.0.2', key: 'secret'})
+
+        await assert.rejects(() => api.getState())
+
+        const fallbackMessage = infoLogs.filter((message) => message.includes('Host may be down, IP:10.0.0.2'))
+        assert.equal(fallbackMessage.length, 1)
+    })
+})

--- a/test/open_garage_test.js
+++ b/test/open_garage_test.js
@@ -30,8 +30,13 @@ class Characteristic {
     }
 
     triggerGetSync() {
-        var result
-        this._on['get']((err, r) => result =r )
+        let error, result
+        this._on['get']((err, r) => {
+            error = err
+            result = r
+        })
+        if (error)
+            throw error
         return result
     }
 
@@ -52,17 +57,19 @@ class Characteristic {
 }
 
 class GarageDoorOpener extends MockDevice {}
+class OccupancySensor extends MockDevice {}
 const MockHomebridge = {
     hap: {
         uuid: { generate: (input) => input },
-        Service: {GarageDoorOpener},
+        Service: {GarageDoorOpener, OccupancySensor},
         Characteristic: {
             Manufacturer: {name: "Manufacturer"},
             Model: {name: "Model"},
             SerialNumber: {name: "SerialNumber"},
             TargetDoorState: {name: "TargetDoorState", CLOSED: "T_CLOSED", OPEN: "T_OPEN"},
             CurrentDoorState: {name: "CurrentDoorState", CLOSED: "CLOSED", OPEN: "OPEN"},
-            ObstructionDetected: {name: "ObstructionDetected"}
+            ObstructionDetected: {name: "ObstructionDetected"},
+            OccupancyDetected: {name: "OccupancyDetected", OCCUPANCY_DETECTED: "DETECTED", OCCUPANCY_NOT_DETECTED: "NOT_DETECTED"}
         }
     }
 }
@@ -98,8 +105,8 @@ describe('OpenGarage', function() {
     var MockDate
     var currentDoorState
     var targetDoorState
-    let pollFrequencyMs = OpenGarageModule.defaults.pollFrequencyMs
-    var openDurationMs = OpenGarageModule.defaults.openDurationMs
+    const pollFrequencyMs = OpenGarageModule.defaults.pollFrequencySecs * 1000
+    const openDurationMs = OpenGarageModule.defaults.openCloseDurationSecs * 1000
     let Characteristic = MockHomebridge.hap.Characteristic
     let Service = MockHomebridge.hap.Service
 


### PR DESCRIPTION
## Summary
- derive the OpenGarage test timing expectations from the second-based defaults
- improve the mock HomeKit surface so error handling and occupancy checks behave like the runtime
- update the npm test script to execute the mocha suite
- log a warning when OpenGarage polling times out and surface the target IP in the message
- allow injecting a request client into the API and cover the timeout logging behaviour with new tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d831b7d7108324aa32d6e8e52c6400