### PR TITLE
Warn when OpenGarage host is unreachable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Update your config.json configuration file. See the example below.
 - `key` - The password to control your OpenGarage device
 - `openCloseDurationSecs` - The amount of time within which an open/close transition should reliably complete (and OpenGarage will sense the new door state), including the OpenGarage warning beeps.
 - `pollFrequencySecs` - How often to poll OpenGarage for state changes. This will enable state updates for the garage door when not controlled via this homebridge plugin.
+- `debug` - Optional. Enable verbose logging of API calls when `true`. Defaults to `false`.
 
 ### Sample config.json
 
@@ -50,7 +51,8 @@ Update your config.json configuration file. See the example below.
                 "ip": "192.168.0.4",
                 "key": "YourPassword",
                 "openCloseDurationSecs": 22,
-                "pollFrequencySecs": 60
+                "pollFrequencySecs": 60,
+                "debug": true
             }
         ]
     }

--- a/index.js
+++ b/index.js
@@ -1,26 +1,33 @@
 const OpenGarageModule = require("./lib/open_garage.js")
 const OpenGarageApiModule = require("./lib/open_garage_api.js")
 
-module.exports = function( homebridge ) {
-    let Service = homebridge.hap.Service
-    let Characteristic = homebridge.hap.Characteristic
+let Service
+let Characteristic
 
-    class OpenGarageConnect {
-        constructor(log, config) {
-            let OpenGarageApi = OpenGarageApiModule(log)
-            let openGarageApi = new OpenGarageApi({
-                ip: config.ip,
-                key: config.key
-            })
-            let OpenGarage = OpenGarageModule(log, config, {Service, Characteristic, openGarageApi, setTimeout, clearTimeout, Date})
-            this.openGarage = new OpenGarage(config.name, true)
-        }
-        getServices() {
-            return([
-		   this.openGarage.garageService,
-		   this.openGarage.vehicleService,
-	           ])
-        }
+class OpenGarageConnect {
+    constructor(log, config) {
+        const debugEnabled = !!config.debug
+
+        const OpenGarageApi = OpenGarageApiModule(log)
+        const openGarageApi = new OpenGarageApi({
+            ip: config.ip,
+            key: config.key,
+            debug: debugEnabled
+        })
+        const moduleConfig = Object.assign({}, config, {debug: debugEnabled})
+        const OpenGarage = OpenGarageModule(log, moduleConfig, {Service, Characteristic, openGarageApi, setTimeout, clearTimeout, Date})
+        this.openGarage = new OpenGarage(config.name, true)
     }
-    homebridge.registerAccessory( "homebridge-og", "OpenGarage", OpenGarageConnect );
-};
+    getServices() {
+        return([
+               this.openGarage.garageService,
+               this.openGarage.vehicleService,
+               ])
+    }
+}
+
+module.exports = (api) => {
+    Service = api.hap.Service
+    Characteristic = api.hap.Characteristic
+    api.registerAccessory("homebridge-og", "OpenGarage", OpenGarageConnect)
+}

--- a/lib/open_garage.js
+++ b/lib/open_garage.js
@@ -1,6 +1,14 @@
-const request = require("request-promise-native")
+function createDebugLogger(log, enabled) {
+    const debugFn = (typeof log.debug === 'function') ? log.debug.bind(log) : log
+    return function(...args) {
+        if (!enabled)
+            return
+        debugFn(...args)
+    }
+}
 
 function OpenGarageModule(log, config, {Service, Characteristic, openGarageApi, setTimeout, clearTimeout, Date}) {
+    const debugLog = createDebugLogger(log, !!config.debug)
     let openCloseDurationMs = (config.openCloseDurationSecs || OpenGarageModule.defaults.openCloseDurationSecs) * 1000
     let pollFrequencyMs = (config.pollFrequencySecs || OpenGarageModule.defaults.pollFrequencySecs) * 1000
     function after(ms, result) {
@@ -46,6 +54,7 @@ function OpenGarageModule(log, config, {Service, Characteristic, openGarageApi, 
             this.vehicleService.getCharacteristic( Characteristic.OccupancyDetected )
                 .on( "get", syncGetter(this.getVehicleOccupancy.bind ( this ) ) )
 
+            debugLog("Debug logging enabled for %s", this.name)
             this.pollStateRefreshLoop()
         }
 
@@ -112,11 +121,12 @@ function OpenGarageModule(log, config, {Service, Characteristic, openGarageApi, 
         }
 
         triggerStateRefresh() {
+            debugLog("Triggering state refresh for %s", this.name)
             return openGarageApi.getState().then(
                 (state) => {
                     this.currentState = {success: state}
                     this.notify()
-                    log.debug( "Poll status garage: %s", this.isClosed() ? "closed" : "open" )
+                    debugLog( "Poll status garage: %s", this.isClosed() ? "closed" : "open" )
                     return this.isClosed()
                 },
                 (error) => {
@@ -129,6 +139,7 @@ function OpenGarageModule(log, config, {Service, Characteristic, openGarageApi, 
         pollStateRefreshLoop() {
             // reset poll timer if already set
             if (this.pollTimer) clearTimeout(this.pollTimer)
+            debugLog("Scheduling next poll in %dms", pollFrequencyMs)
             this.pollTimer = setTimeout(() => this.pollStateRefreshLoop(), pollFrequencyMs)
 
             this.triggerStateRefresh().catch((err) => {
@@ -149,6 +160,7 @@ function OpenGarageModule(log, config, {Service, Characteristic, openGarageApi, 
             let targetStateClosed = state === Characteristic.TargetDoorState.CLOSED
             log( "Set state to %s", targetStateClosed ? "closed" : "open" )
 
+            debugLog("Sending target state %s request", targetStateClosed ? "closed" : "open")
             openGarageApi.setTargetState(targetStateClosed)
                 .then(
                     (_) => {

--- a/lib/open_garage_api.js
+++ b/lib/open_garage_api.js
@@ -1,10 +1,22 @@
 const request = require("request-promise-native")
 
-function OpenGarageApiModule(log) {
+function createDebugLogger(log, enabled) {
+    const debugFn = (typeof log.debug === 'function') ? log.debug.bind(log) : log
+    return function(...args) {
+        if (!enabled)
+            return
+        debugFn(...args)
+    }
+}
+
+function OpenGarageApiModule(log, deps = {}) {
+    const requestClient = deps.request || request
     class OpenGarageApi{
-        constructor({ip, key}) {
+        constructor({ip, key, debug = false}) {
             this.key = key
+            this.ip = ip
             this.baseUrl = "http://" + ip
+            this.debugLog = createDebugLogger(log, !!debug)
         }
 
         urlFor(path, params) {
@@ -16,10 +28,16 @@ function OpenGarageApiModule(log) {
 
 
         getState() {
-            return request.get({ url: this.urlFor("/jc") }).then(
+            this.debugLog("GET %s/jc", this.baseUrl)
+            return requestClient.get({ url: this.urlFor("/jc") }).then(
                 (body) => JSON.parse(body),
                 (err) => {
                     log("Error getting state:", err.message)
+                    let timeout = err && (err.code === "ETIMEDOUT" || (err.cause && err.cause.code === "ETIMEDOUT"))
+                    if (timeout) {
+                        const warn = typeof log.warn === "function" ? log.warn.bind(log) : log
+                        warn("Host may be down, IP:%s", this.ip)
+                    }
                     throw err
                 })
         }
@@ -45,8 +63,8 @@ function OpenGarageApiModule(log) {
             let url = this.urlFor(
                 "/cc",
                 closed ? "close=1" : "open=1")
-            log(url)
-            return request.get({url}).then((body) => this._handleResponse(body))
+            this.debugLog("GET %s", url.replace(/dkey=[^&]+/, "dkey=***"))
+            return requestClient.get({url}).then((body) => this._handleResponse(body))
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
 		"eslint": "^4.9.0"
 	},
 	"directories": {},
-	"engines": {
-		"homebridge": ">=0.4.0",
-		"node": ">=8.1.4"
-	},
+        "engines": {
+                "homebridge": ">=2.0.0",
+                "node": ">=8.1.4"
+        },
 	"keywords": [
 		"homebridge-plugin",
 		"OpenGarage"
@@ -36,8 +36,8 @@
 	],
 	"name": "homebridge-og",
 	"optionalDependencies": {},
-	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 1"
-	},
+        "scripts": {
+                "test": "mocha"
+        },
 	"version": "3.1.1"
 }

--- a/test/open_garage_api_test.js
+++ b/test/open_garage_api_test.js
@@ -1,0 +1,73 @@
+const assert = require('assert')
+const util = require('util')
+const OpenGarageApiModule = require('../lib/open_garage_api.js')
+
+describe('OpenGarageApi', function() {
+    it('logs a warning when requests time out', async function() {
+        const logs = []
+        const warns = []
+        function log() {
+            logs.push(util.format.apply(util, arguments))
+        }
+        log.warn = function() {
+            warns.push(util.format.apply(util, arguments))
+        }
+
+        const request = {
+            get: () => Promise.reject(Object.assign(new Error('read ETIMEDOUT'), {code: 'ETIMEDOUT'}))
+        }
+
+        const OpenGarageApi = OpenGarageApiModule(log, {request})
+        const api = new OpenGarageApi({ip: '10.0.0.1', key: 'secret'})
+
+        await assert.rejects(() => api.getState())
+
+        assert(logs.some((message) => message.includes('Error getting state: read ETIMEDOUT')))
+        assert(warns.some((message) => message.includes('Host may be down, IP:10.0.0.1')))
+    })
+
+    it('falls back to info logging when warn is unavailable', async function() {
+        const infoLogs = []
+        function log() {
+            infoLogs.push(util.format.apply(util, arguments))
+        }
+
+        const request = {
+            get: () => Promise.reject(Object.assign(new Error('read ETIMEDOUT'), {code: 'ETIMEDOUT'}))
+        }
+
+        const OpenGarageApi = OpenGarageApiModule(log, {request})
+        const api = new OpenGarageApi({ip: '10.0.0.2', key: 'secret'})
+
+        await assert.rejects(() => api.getState())
+
+        const fallbackMessage = infoLogs.filter((message) => message.includes('Host may be down, IP:10.0.0.2'))
+        assert.equal(fallbackMessage.length, 1)
+    })
+
+    it('logs additional details when debug is enabled', async function() {
+        const debugLogs = []
+        function log() {}
+        log.debug = function() {
+            debugLogs.push(util.format.apply(util, arguments))
+        }
+
+        const request = {
+            get: ({url}) => {
+                if (url.includes('/jc'))
+                    return Promise.resolve(JSON.stringify({door: 0}))
+
+                return Promise.resolve(JSON.stringify({result: 1}))
+            }
+        }
+
+        const OpenGarageApi = OpenGarageApiModule(log, {request})
+        const api = new OpenGarageApi({ip: '10.0.0.3', key: 'secret', debug: true})
+
+        await api.getState()
+        await api.setTargetState(true)
+
+        assert(debugLogs.some((message) => message.includes('GET http://10.0.0.3/jc')))
+        assert(debugLogs.some((message) => message.includes('dkey=***')))
+    })
+})

--- a/test/open_garage_test.js
+++ b/test/open_garage_test.js
@@ -30,8 +30,13 @@ class Characteristic {
     }
 
     triggerGetSync() {
-        var result
-        this._on['get']((err, r) => result =r )
+        let error, result
+        this._on['get']((err, r) => {
+            error = err
+            result = r
+        })
+        if (error)
+            throw error
         return result
     }
 
@@ -52,17 +57,19 @@ class Characteristic {
 }
 
 class GarageDoorOpener extends MockDevice {}
+class OccupancySensor extends MockDevice {}
 const MockHomebridge = {
     hap: {
         uuid: { generate: (input) => input },
-        Service: {GarageDoorOpener},
+        Service: {GarageDoorOpener, OccupancySensor},
         Characteristic: {
             Manufacturer: {name: "Manufacturer"},
             Model: {name: "Model"},
             SerialNumber: {name: "SerialNumber"},
             TargetDoorState: {name: "TargetDoorState", CLOSED: "T_CLOSED", OPEN: "T_OPEN"},
             CurrentDoorState: {name: "CurrentDoorState", CLOSED: "CLOSED", OPEN: "OPEN"},
-            ObstructionDetected: {name: "ObstructionDetected"}
+            ObstructionDetected: {name: "ObstructionDetected"},
+            OccupancyDetected: {name: "OccupancyDetected", OCCUPANCY_DETECTED: "DETECTED", OCCUPANCY_NOT_DETECTED: "NOT_DETECTED"}
         }
     }
 }
@@ -98,8 +105,8 @@ describe('OpenGarage', function() {
     var MockDate
     var currentDoorState
     var targetDoorState
-    let pollFrequencyMs = OpenGarageModule.defaults.pollFrequencyMs
-    var openDurationMs = OpenGarageModule.defaults.openDurationMs
+    const pollFrequencyMs = OpenGarageModule.defaults.pollFrequencySecs * 1000
+    const openDurationMs = OpenGarageModule.defaults.openCloseDurationSecs * 1000
     let Characteristic = MockHomebridge.hap.Characteristic
     let Service = MockHomebridge.hap.Service
 


### PR DESCRIPTION
## Summary
- derive the OpenGarage test timing expectations from the second-based defaults
- improve the mock HomeKit surface so error handling and occupancy checks behave like the runtime
- update the npm test script to execute the mocha suite
- log a warning when OpenGarage polling times out and surface the target IP in the message
- allow injecting a request client into the API and cover the timeout logging behaviour with new tests
- register the accessory through the Homebridge 2 API and require Homebridge 2.0.0 or newer
- add an optional debug flag to enable verbose API logging and document the configuration knob

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d831b7d7108324aa32d6e8e52c6400