### PR TITLE
Align plugin documentation with Homebridge 2 requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ made to work with OpenGarage
 
 This plugin only works with OpenGarage Firmware 1.0.8 or later.
 
-You must have NodeJS `v8.1.4` or later installed as `homebridge-og` depends on JavaScript features introduced at that point. Check your node version:
+You must have Node.js `v16.0.0` or later installed, matching the minimum runtime required by Homebridge 2. Check your node version:
 
 ```
 node --version
 ```
 
-You need [Homebridge](https://github.com/nfarina/homebridge) installed and configured. This plugin was developed against Homebridge `0.4.43`.
+You need [Homebridge](https://github.com/nfarina/homebridge) installed and configured. This plugin requires Homebridge `2.0.0` or later.
 
 ```
 npm install -g homebridge

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 	"directories": {},
         "engines": {
                 "homebridge": ">=2.0.0",
-                "node": ">=8.1.4"
+                "node": ">=16.0.0"
         },
 	"keywords": [
 		"homebridge-plugin",


### PR DESCRIPTION
## Summary
- update the installation instructions to document the Homebridge 2 and Node.js 16 minimums
- bump the package.json engines.node constraint to enforce the supported runtime

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d83d4ab9148324b68b9fb5393af790